### PR TITLE
Logging: set file to read-only & add logging mode option

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -104,8 +104,7 @@
 #Mavlink-router serves on this TCP port
 TcpServerPort=5790
 ReportStats=false
-#Which mavlink dialect is being used. Can be `common`[default] or `ardupilotmega`
-MavlinkDialect=ardupilotmega
+MavlinkDialect=auto
 
 [UdpEndpoint alfa]
 Mode = Eavesdropping

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -31,6 +31,12 @@
 #       Path to directory where to store flightstack log.
 #       No default value. If absent, no flightstack log will be stored.
 #
+#   LogMode
+#       One of <always>, <while_armed>
+#       Default: always, log from start until mavlink-router is stopped.
+#       If set to while_armed, a new log file is created whenever the vehicle is
+#       armed, and closed when disarmed.
+#
 #   DebugLogLevel
 #       One of <error>, <warning>, <info> or <debug>. Which debug log
 #       level is being used by mavlink-router, with <debug> being the

--- a/src/common/conf_file.h
+++ b/src/common/conf_file.h
@@ -121,6 +121,7 @@ public:
     // Helpers
     static int parse_bool(const char *val, size_t val_len, void *storage, size_t storage_len);
     static int parse_str_dup(const char *val, size_t val_len, void *storage, size_t storage_len);
+    static int parse_log_mode(const char *val, size_t val_len, void *storage, size_t storage_len);
     static int parse_str_buf(const char *val, size_t val_len, void *storage, size_t storage_len);
 
 #define DECLARE_PARSE_INT(_type) \

--- a/src/mavlink-router/autolog.cpp
+++ b/src/mavlink-router/autolog.cpp
@@ -56,11 +56,9 @@ int AutoLog::write_msg(const struct buffer *buffer)
     /* We check autopilot on heartbeat */
     log_debug("Got autopilot %u from heartbeat", heartbeat->autopilot);
     if (heartbeat->autopilot == MAV_AUTOPILOT_PX4) {
-        _logger = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir));
-        _logger->start();
+        _logger = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir, _mode));
     } else if (heartbeat->autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-        _logger = std::unique_ptr<LogEndpoint>(new BinLog(_logs_dir));
-        _logger->start();
+        _logger = std::unique_ptr<LogEndpoint>(new BinLog(_logs_dir, _mode));
     } else {
         log_warning("Unidentified autopilot, cannot start flight stack logging");
     }
@@ -76,8 +74,6 @@ void AutoLog::stop()
 
 bool AutoLog::start()
 {
-    _add_sys_comp_id(LOG_ENDPOINT_SYSTEM_ID << 8);
-
     return true;
 }
 

--- a/src/mavlink-router/autolog.h
+++ b/src/mavlink-router/autolog.h
@@ -24,8 +24,9 @@
 
 class AutoLog : public LogEndpoint {
 public:
-    AutoLog(const char *logs_dir)
-        : LogEndpoint{"AutoLog", logs_dir}
+
+    AutoLog(const char *logs_dir, LogMode mode)
+        : LogEndpoint{"AutoLog", logs_dir, mode}
     {
     }
 

--- a/src/mavlink-router/binlog.h
+++ b/src/mavlink-router/binlog.h
@@ -24,8 +24,8 @@
 
 class BinLog : public LogEndpoint {
 public:
-    BinLog(const char *logs_dir)
-        : LogEndpoint{"BinLog", logs_dir}
+    BinLog(const char *logs_dir, LogMode mode)
+        : LogEndpoint{"BinLog", logs_dir, mode}
     {
     }
 

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -57,7 +57,9 @@ protected:
     virtual bool _alive_timeout();
 
 private:
-    int _get_file(const char *extension, char *filename_result, size_t filename_size);
+    int _get_file(const char *extension);
     uint32_t _get_prefix(DIR *dir);
     DIR *_open_or_create_dir(const char *name);
+
+    char _filename[64];
 };

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -258,9 +258,6 @@ void Mainloop::loop()
 
     setup_signal_handlers();
 
-    if (_log_endpoint)
-        _log_endpoint->start();
-
     add_timeout(LOG_AGGREGATE_INTERVAL_SEC * MSEC_PER_SEC,
                 std::bind(&Mainloop::_log_aggregate_timeout, this, std::placeholders::_1), this);
 
@@ -431,11 +428,11 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
 
     if (opt->logs_dir) {
         if (opt->mavlink_dialect == Ardupilotmega) {
-            _log_endpoint = new BinLog(opt->logs_dir);
+            _log_endpoint = new BinLog(opt->logs_dir, opt->log_mode);
         } else if (opt->mavlink_dialect == Common) {
-            _log_endpoint = new ULog(opt->logs_dir);
+            _log_endpoint = new ULog(opt->logs_dir, opt->log_mode);
         } else {
-            _log_endpoint = new AutoLog(opt->logs_dir);
+            _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode);
         }
         g_endpoints[i] = _log_endpoint;
     }

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -126,6 +126,7 @@ struct options {
     unsigned long tcp_port;
     bool report_msg_statistics;
     char *logs_dir;
+    LogMode log_mode;
     int debug_log_level;
     enum mavlink_dialect mavlink_dialect;
 };

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -23,8 +23,8 @@
 
 class ULog : public LogEndpoint {
 public:
-    ULog(const char *logs_dir)
-        : LogEndpoint{"ULog", logs_dir}
+    ULog(const char *logs_dir, LogMode mode)
+        : LogEndpoint{"ULog", logs_dir, mode}
     {
     }
 


### PR DESCRIPTION
This PR includes 2 changes:
- change the log file permissions to read-only after the file is closed. This can be used by other clients to detect when logging is finished
- add an option `LogMode` that can be set to `arm_until_disarm`. In that case logging is started when the vehicle is armed and stopped when disarmed. The default is `always`, which is the same behavior as before.