### PR TITLE
logging: use dash on config entry

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -32,9 +32,9 @@
 #       No default value. If absent, no flightstack log will be stored.
 #
 #   LogMode
-#       One of <always>, <while_armed>
+#       One of <always>, <while-armed>
 #       Default: always, log from start until mavlink-router is stopped.
-#       If set to while_armed, a new log file is created whenever the vehicle is
+#       If set to while-armed, a new log file is created whenever the vehicle is
 #       armed, and closed when disarmed.
 #
 #   DebugLogLevel

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -599,7 +599,7 @@ static int parse_log_mode(const char *val, size_t val_len, void *storage, size_t
     LogMode log_mode;
     if (strcaseeq(log_mode_str, "always"))
         log_mode = LogMode::always;
-    else if (strcaseeq(log_mode_str, "while_armed"))
+    else if (strcaseeq(log_mode_str, "while-armed"))
         log_mode = LogMode::while_armed;
     else {
         log_error("Invalid argument for LogMode = %s", log_mode_str);


### PR DESCRIPTION
We don't use underscores in config entries: a dash should rather be
used.