### PR TITLE
Revert "endpoint: set RTS/DTR state"

### DIFF
--- a/examples/receiver.py
+++ b/examples/receiver.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 
 from __future__ import print_function
-from __future__ import print_function
 
 import pymavlink.mavutil as mavutil
 import sys

--- a/examples/sender.py
+++ b/examples/sender.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 
 from __future__ import print_function
-from __future__ import print_function
 from threading import Thread
 from time import sleep
 

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -497,8 +497,6 @@ int UartEndpoint::set_flow_control(bool enabled)
 int UartEndpoint::open(const char *path)
 {
     struct termios2 tc;
-    const int bit_dtr = TIOCM_DTR;
-    const int bit_rts = TIOCM_RTS;
 
     fd = ::open(path, O_RDWR|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
     if (fd < 0) {
@@ -569,14 +567,6 @@ int UartEndpoint::open(const char *path)
     }
 
 set_latency_failed:
-
-    /* set DTR/RTS */
-    if (ioctl(fd, TIOCMBIS, &bit_dtr) == -1 ||
-        ioctl(fd, TIOCMBIS, &bit_rts) == -1) {
-        log_error("Could not set DTR/RTS (%m)");
-        goto fail;
-    }
-
     if (ioctl(fd, TCFLSH, TCIOFLUSH) == -1) {
         log_error("Could not flush terminal (%m)");
         goto fail;


### PR DESCRIPTION
This reverts commit 940f0b8caf3cf61879c3cdfebd66a78eb127bd70.

I think this was probably one artficact of putting the uart in raw mode
rather than sane mode. We don't care about RTS/DTR and none of the
flight stacks we support are setting those.

Fix #128, but needs testing