### PR TITLE
logging: allow autopilot logging from an arbitrary system id

### DIFF
--- a/src/mavlink-router/binlog.cpp
+++ b/src/mavlink-router/binlog.cpp
@@ -100,6 +100,12 @@ int BinLog::write_msg(const struct buffer *buffer)
         source_component_id = msg->compid;
     }
 
+    /* set the expected system id to the first autopilot that we get a heartbeat from */
+    if (_target_system_id == -1 && msg_id == MAVLINK_MSG_ID_HEARTBEAT
+        && source_component_id == MAV_COMP_ID_AUTOPILOT1) {
+        _target_system_id = source_system_id;
+    }
+
     /* Check if we should start or stop logging */
     _handle_auto_start_stop(msg_id, source_system_id, source_component_id, payload);
 

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -215,13 +215,16 @@ bool LogEndpoint::_start_alive_timeout()
 void LogEndpoint::_handle_auto_start_stop(uint32_t msg_id, uint8_t source_system_id,
         uint8_t source_component_id, uint8_t *payload)
 {
+    if (_target_system_id == -1) { // wait until initialized
+        return;
+    }
     if (_mode == LogMode::always) {
         if (_file == -1) {
             if (!start()) _mode = LogMode::disabled;
         }
     } else if (_mode == LogMode::while_armed) {
-        if (msg_id == MAVLINK_MSG_ID_HEARTBEAT &&
-                source_system_id == LOG_ENDPOINT_TARGET_SYSTEM_ID && source_component_id == MAV_COMP_ID_AUTOPILOT1) {
+        if (msg_id == MAVLINK_MSG_ID_HEARTBEAT && source_system_id == _target_system_id
+            && source_component_id == MAV_COMP_ID_AUTOPILOT1) {
 
             const mavlink_heartbeat_t *heartbeat = (mavlink_heartbeat_t *)payload;
             const bool is_armed = heartbeat->system_status == MAV_STATE_ACTIVE;

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -24,7 +24,6 @@
 #include "timeout.h"
 
 #define LOG_ENDPOINT_SYSTEM_ID 2
-#define LOG_ENDPOINT_TARGET_SYSTEM_ID 1
 
 
 enum class LogMode {
@@ -51,7 +50,7 @@ public:
 
 protected:
     const char *_logs_dir;
-    const int _target_system_id = LOG_ENDPOINT_TARGET_SYSTEM_ID;
+    int _target_system_id = -1;
     int _file = -1;
     LogMode _mode;
 

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -128,6 +128,12 @@ int ULog::write_msg(const struct buffer *buffer)
         source_component_id = msg->compid;
     }
 
+    /* set the expected system id to the first autopilot that we get a heartbeat from */
+    if (_target_system_id == -1 && msg_id == MAVLINK_MSG_ID_HEARTBEAT
+        && source_component_id == MAV_COMP_ID_AUTOPILOT1) {
+        _target_system_id = source_system_id;
+    }
+
     /* Check if we should start or stop logging */
     _handle_auto_start_stop(msg_id, source_system_id, source_component_id, payload);
 


### PR DESCRIPTION
The expected system id for log streaming was hardcoded to 1, and thus
logging would not work when the autpilot is configured to have a different
sys id.

This patch changes the behavior to pick up the system id from the heartbeat
of the autopilot.