### PR TITLE
mainloop: handle epoll_wait error

### DIFF
--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -288,6 +288,13 @@ void Mainloop::loop()
                     mod_fd(p->fd, p, EPOLLIN);
                 }
             }
+            if (events[i].events & EPOLLERR) {
+                log_error("poll error for fd %i, closing it", p->fd);
+                remove_fd(p->fd);
+                // make poll errors fatal so that an external component can
+                // restart mavlink-router
+                should_exit = true;
+            }
         }
 
         if (should_process_tcp_hangups) {


### PR DESCRIPTION
epoll can fail for example when an UART FTDI cable is plugged out and the
associated device becomes invalid. In that case we remove the file
descriptor from the list.

We also quit mavlink-router, because in most cases the error is fatal,
and an external component (e.g. systemd) can restart it.
If this behavior is not desired by default, we can make it a config option.

The current behavior is that mavlink-router busy-loops in case the cable is plugged out.