### PR TITLE
add support for musl

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -56,3 +56,14 @@ int mkdir_p(const char *path, int len, mode_t mode);
 #ifdef __cplusplus
 }
 #endif
+
+#ifndef strndupa
+#define strndupa(s, n) \
+       (__extension__ ({const char *__in = (s); \
+                        size_t __len = strnlen (__in, (n)); \
+                        char *__out = (char *) alloca (__len + 1); \
+                        __out[__len] = '\0'; \
+                        (char *) memcpy (__out, __in, __len);}))
+
+#include <asm/ioctls.h>
+#endif


### PR DESCRIPTION
Following the Gentoo patch here: https://cgit.gentoo.org/proj/musl.git/tree/sys-libs/efivar/files/27-strndupa.patch?id=0d259ad72bb04c5a9bc1c83d3

This enables build on musl-based systems (e.g. Alpine Linux).