### PR TITLE
Improve behaviour in case of serial port errors

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -72,7 +72,7 @@ int Endpoint::handle_read()
     uint8_t src_sysid, src_compid;
     struct buffer buf{};
 
-    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid)) > 0)
+    if ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid)) > 0)
         Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid, src_sysid,
                                            src_compid);
 

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -84,6 +84,7 @@ public:
     virtual void print_statistics();
     virtual int write_msg(const struct buffer *pbuf) = 0;
     virtual int flush_pending_msgs() = 0;
+    virtual int reopen() { return -1; };
 
     void log_aggregate(unsigned int interval_sec);
 
@@ -141,6 +142,7 @@ public:
     int flush_pending_msgs() override { return -ENOSYS; }
 
     int open(const char *path, std::vector<unsigned long> baudrates, bool flowcontrol);
+    virtual int reopen();
 
 protected:
     int read_msg(struct buffer *pbuf, int *target_system, int *target_compid, uint8_t *src_sysid,
@@ -150,7 +152,9 @@ protected:
 private:
     size_t _current_baud_idx = 0;
     Timeout *_change_baud_timeout = nullptr;
+    std::string _path;
     std::vector<unsigned long> _baudrates;
+    bool _flowcontrol;
 
     bool _change_baud_cb(void *data);
 

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -140,10 +140,7 @@ public:
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
 
-    int open(const char *path);
-    int set_speed(speed_t baudrate);
-    int set_flow_control(bool enabled);
-    int add_speeds(std::vector<unsigned long> baudrates);
+    int open(const char *path, std::vector<unsigned long> baudrates, bool flowcontrol);
 
 protected:
     int read_msg(struct buffer *pbuf, int *target_system, int *target_compid, uint8_t *src_sysid,
@@ -156,6 +153,10 @@ private:
     std::vector<unsigned long> _baudrates;
 
     bool _change_baud_cb(void *data);
+
+    int set_speed(speed_t baudrate);
+    int set_flow_control(bool enabled);
+    int add_speeds(std::vector<unsigned long> baudrates);
 };
 
 class UdpEndpoint : public Endpoint {

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -24,6 +24,8 @@
 #include <unistd.h>
 
 #include <memory>
+#include <thread>
+#include <chrono>
 
 #include <common/log.h>
 #include <common/util.h>
@@ -265,8 +267,10 @@ void Mainloop::loop()
         int i;
 
         r = epoll_wait(epollfd, events, max_events, -1);
-        if (r < 0 && errno == EINTR)
+        if (r < 0 && errno == EINTR) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
             continue;
+        }
 
         for (i = 0; i < r; i++) {
             if (events[i].data.ptr == &g_tcp_fd) {

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -373,20 +373,8 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
         switch (conf->type) {
         case Uart: {
             std::unique_ptr<UartEndpoint> uart{new UartEndpoint{}};
-            if (uart->open(conf->device) < 0)
+            if (uart->open(conf->device, *conf->bauds, conf->flowcontrol) < 0) {
                 return false;
-
-            if (conf->bauds->size() == 1) {
-                if (uart->set_speed((*(conf->bauds))[0]) < 0)
-                    return false;
-            } else {
-                if (uart->add_speeds(*conf->bauds) < 0)
-                    return false;
-            }
-
-            if (conf->flowcontrol) {
-                if (uart->set_flow_control(true) < 0)
-                    return false;
             }
 
             g_endpoints[i] = uart.release();

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -302,7 +302,7 @@ void Mainloop::loop()
                         succeeded = true;
                         break;
                     }
-                    std::this_thread::sleep_for(std::chrono::milliseconds(222));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
                 }
                 if (!succeeded) {
                     log_error("poll error for fd %i, closing it", p->fd);

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -295,7 +295,7 @@ void Mainloop::loop()
             if (events[i].events & EPOLLERR) {
                 remove_fd(p->fd);
 
-                if (g_endpoints[i]->reopen()) {
+                if (g_endpoints[i]->reopen() >= 0) {
                     log_error("poll error for fd %i, reopening it", p->fd);
                     add_fd(g_endpoints[i]->fd, g_endpoints[i], EPOLLIN);
                 } else {


### PR DESCRIPTION
- In case of errors call thread sleep to avoid busy looping.
- In case of epoll error try to reopen serial port for several times before exiting the application.