### PR TITLE
Improve behaviour in case of serial port errors

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -72,7 +72,7 @@ int Endpoint::handle_read()
     uint8_t src_sysid, src_compid;
     struct buffer buf{};
 
-    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid)) > 0)
+    if ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid)) > 0)
         Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid, src_sysid,
                                            src_compid);
 
@@ -486,11 +486,22 @@ int UartEndpoint::set_flow_control(bool enabled)
     return 0;
 }
 
-int UartEndpoint::open(const char *path)
+int UartEndpoint::reopen()
+{
+    if (fd >= 0) {
+      ::close(fd);
+    }
+    return open(_path.c_str(), _baudrates, _flowcontrol);
+}
+
+int UartEndpoint::open(const char *path, std::vector<unsigned long> baudrates, bool flowcontrol)
 {
     struct termios2 tc;
     const int bit_dtr = TIOCM_DTR;
     const int bit_rts = TIOCM_RTS;
+
+    _path = path;
+    _flowcontrol = flowcontrol;
 
     fd = ::open(path, O_RDWR|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
     if (fd < 0) {
@@ -547,6 +558,18 @@ int UartEndpoint::open(const char *path)
     if (ioctl(fd, TCFLSH, TCIOFLUSH) == -1) {
         log_error("Could not flush terminal (%m)");
         goto fail;
+    }
+
+    if (add_speeds(baudrates) < 0) {
+        log_error("Could not set baud rate (%m)");
+        goto fail;
+    }
+
+    if (flowcontrol) {
+        if (set_flow_control(true) < 0) {
+            log_error("Could not set flow control (%m)");
+            goto fail;
+        }
     }
 
     log_info("Open UART [%d] %s *", fd, path);
@@ -627,12 +650,17 @@ int UartEndpoint::write_msg(const struct buffer *pbuf)
 
 int UartEndpoint::add_speeds(std::vector<unsigned long> bauds)
 {
-    if (!bauds.size())
+    if (!bauds.size()) {
         return -EINVAL;
+    }
 
     _baudrates = bauds;
 
-    set_speed(_baudrates[0]);
+    set_speed(bauds[0]);
+
+    if (bauds.size() == 1) {
+        return 0;
+    }
 
     _change_baud_timeout = Mainloop::get_instance().add_timeout(
         MSEC_PER_SEC * UART_BAUD_RETRY_SEC,

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -84,6 +84,7 @@ public:
     virtual void print_statistics();
     virtual int write_msg(const struct buffer *pbuf) = 0;
     virtual int flush_pending_msgs() = 0;
+    virtual int reopen() { return -1; };
 
     void log_aggregate(unsigned int interval_sec);
 
@@ -140,10 +141,8 @@ public:
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
 
-    int open(const char *path);
-    int set_speed(speed_t baudrate);
-    int set_flow_control(bool enabled);
-    int add_speeds(std::vector<unsigned long> baudrates);
+    int open(const char *path, std::vector<unsigned long> baudrates, bool flowcontrol);
+    virtual int reopen();
 
 protected:
     int read_msg(struct buffer *pbuf, int *target_system, int *target_compid, uint8_t *src_sysid,
@@ -153,9 +152,15 @@ protected:
 private:
     size_t _current_baud_idx = 0;
     Timeout *_change_baud_timeout = nullptr;
+    std::string _path;
     std::vector<unsigned long> _baudrates;
+    bool _flowcontrol;
 
     bool _change_baud_cb(void *data);
+
+    int set_speed(speed_t baudrate);
+    int set_flow_control(bool enabled);
+    int add_speeds(std::vector<unsigned long> baudrates);
 };
 
 class UdpEndpoint : public Endpoint {


### PR DESCRIPTION
This change tries to avoid busy loop that uses 100% CPU when there is an error on serial port and tries to reopen serial port for N of retires times before exiting. 