### PR TITLE
Fixed build for Alpine Linux

### DIFF
--- a/src/common/conf_file.cpp
+++ b/src/common/conf_file.cpp
@@ -515,8 +515,10 @@ int ConfFile::parse_bool(const char *val, size_t val_len, void *storage, size_t 
         if (storage_len < sizeof(_type))                                        \
             return -ENOBUFS;                                                    \
                                                                                 \
-        str = strndupa(val, val_len);                                           \
-        return _func(str, (_type *)storage);                                    \
+        str = strndup(val, val_len);                                            \
+        int res = _func(str, (_type *)storage);                                 \
+        free(str);                                                              \
+        return res;                                                             \
     }
 
 DEFINE_PARSE_INT(i, int, safe_atoi)

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -41,6 +41,13 @@
 
 #define UART_BAUD_RETRY_SEC 5
 
+#ifndef TCGETS2
+#define TCGETS2 TCGETS
+#endif
+#ifndef TCSETS2
+#define TCSETS2 TCSETS
+#endif
+
 Endpoint::Endpoint(const char *name, bool crc_check_enabled)
     : _name{name}
     , _crc_check_enabled{crc_check_enabled}

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -571,15 +571,18 @@ static int parse_log_level(const char *val, size_t val_len, void *storage, size_
     if (val_len > MAX_LOG_LEVEL_SIZE)
         return -EINVAL;
 
-    const char *log_level = strndupa(val, val_len);
+    int ret = 0;
+    char *log_level = strndup(val, val_len);
     int lvl = log_level_from_str(log_level);
     if (lvl == -EINVAL) {
         log_error("Invalid argument for DebugLogLevel = %s", log_level);
-        return -EINVAL;
+        ret = -EINVAL;
+    } else {
+        *((int *)storage) = lvl;
     }
-    *((int *)storage) = lvl;
+    free(log_level);
 
-    return 0;
+    return ret;
 }
 #undef MAX_LOG_LEVEL_SIZE
 
@@ -595,19 +598,24 @@ static int parse_log_mode(const char *val, size_t val_len, void *storage, size_t
     if (val_len > MAX_LOG_MODE_SIZE)
         return -EINVAL;
 
-    const char *log_mode_str = strndupa(val, val_len);
+    int ret = 0;
+    char *log_mode_str = strndup(val, val_len);
     LogMode log_mode;
-    if (strcaseeq(log_mode_str, "always"))
+    if (strcaseeq(log_mode_str, "always")) {
+        *((LogMode *)storage) = log_mode;
         log_mode = LogMode::always;
-    else if (strcaseeq(log_mode_str, "while-armed"))
+    }
+    else if (strcaseeq(log_mode_str, "while-armed")) {
+        *((LogMode *)storage) = log_mode;
         log_mode = LogMode::while_armed;
+    }
     else {
         log_error("Invalid argument for LogMode = %s", log_mode_str);
-        return -EINVAL;
+        ret = -EINVAL;
     }
-    *((LogMode *)storage) = log_mode;
+    free(log_mode_str);
 
-    return 0;
+    return ret;
 }
 #undef MAX_LOG_MODE_SIZE
 


### PR DESCRIPTION
To make mavkink-router build on minimalistic Alpine linux distribution I had to:
- replace strndupa with strndup. stdndupa uses alloca and is not portable. Alloca() allocates memory within the current function's stack frame, so when replacing with strndup we have to call free manually. There were some places where alloca was incorrectly used
- If TCSETS2 or TCGETS2 are not defined then use TCSETS and TCGETS