### PR TITLE
Enable message filtering to reduce network traffic.

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -74,7 +74,7 @@ int Endpoint::handle_read()
     uint32_t msg_id;
     struct buffer buf{};
 
-    if ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid, &msg_id)) > 0)
+    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid, &msg_id)) > 0)
         Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid, src_sysid,
                                            src_compid, msg_id);
 

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -70,20 +70,20 @@ int Endpoint::handle_read()
 {
     int target_sysid, target_compid, r;
     uint8_t src_sysid, src_compid;
+    uint32_t msg_id;
     struct buffer buf{};
 
-    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid)) > 0)
+    if ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid, &msg_id)) > 0)
         Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid, src_sysid,
-                                           src_compid);
+                                           src_compid, msg_id);
 
     return r;
 }
 
 int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid,
-                       uint8_t *src_sysid, uint8_t *src_compid)
+                       uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id)
 {
     bool should_read_more = true;
-    uint32_t msg_id;
     const mavlink_msg_entry_t *msg_entry;
     uint8_t *payload, seq, payload_len;
 
@@ -171,7 +171,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
         if (rx_buf.len < sizeof(*hdr))
             return 0;
 
-        msg_id = hdr->msgid;
+        *msg_id = hdr->msgid;
         payload = rx_buf.data + sizeof(*hdr);
         seq = hdr->seq;
         *src_sysid = hdr->sysid;
@@ -190,7 +190,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
         if (rx_buf.len < sizeof(*hdr))
             return 0;
 
-        msg_id = hdr->msgid;
+        *msg_id = hdr->msgid;
         payload = rx_buf.data + sizeof(*hdr);
         seq = hdr->seq;
         *src_sysid = hdr->sysid;
@@ -212,7 +212,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
     _last_packet_len = expected_size;
     _stat.read.total++;
 
-    msg_entry = mavlink_get_msg_entry(msg_id);
+    msg_entry = mavlink_get_msg_entry(*msg_id);
     if (_crc_check_enabled && msg_entry) {
         /*
          * It is accepting and forwarding unknown messages ids because
@@ -238,7 +238,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
     *target_compid = -1;
 
     if (msg_entry == nullptr) {
-        log_debug("No message entry for %u", msg_id);
+        log_debug("No message entry for %u", *msg_id);
     } else {
         if (msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM) {
             // if target_system is 0, it may have been trimmed out on mavlink2
@@ -256,6 +256,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
                 *target_compid = 0;
             }
         }
+        *msg_id = msg_entry->msgid;
     }
 
     // Check for sequence drops
@@ -309,7 +310,7 @@ bool Endpoint::has_sys_comp_id(unsigned sys_comp_id)
 }
 
 bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid,
-                          uint8_t src_compid)
+                          uint8_t src_compid, uint32_t msg_id)
 {
     if (Log::get_max_level() >= Log::Level::DEBUG) {
         log_debug("Endpoint [%d] got message to %d/%d from %u/%u", fd, target_sysid, target_compid,
@@ -324,6 +325,11 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
     // same channel to avoid loops: reject
     if (has_sys_comp_id(src_sysid, src_compid))
         return false;
+
+    if (msg_id != UINT32_MAX && message_filter.size() > 0 && message_filter.find(msg_id) == message_filter.end()) {
+        // if filter is defined and message is not in the set then discard it
+        return false;
+    }
 
     // Message is broadcast on sysid: accept msg
     if (target_sysid == 0 || target_sysid == -1)
@@ -571,9 +577,9 @@ bool UartEndpoint::_change_baud_cb(void *data)
 }
 
 int UartEndpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid,
-                           uint8_t *src_sysid, uint8_t *src_compid)
+                           uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id)
 {
-    int ret = Endpoint::read_msg(pbuf, target_sysid, target_compid, src_sysid, src_compid);
+    int ret = Endpoint::read_msg(pbuf, target_sysid, target_compid, src_sysid, src_compid, msg_id);
 
     if (_change_baud_timeout != nullptr && ret == ReadOk) {
         log_info("Baudrate %lu responded, keeping it", _baudrates[_current_baud_idx]);

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -18,6 +18,7 @@
 #include "endpoint.h"
 
 #include <arpa/inet.h>
+#include <algorithm>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -326,7 +327,10 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
     if (has_sys_comp_id(src_sysid, src_compid))
         return false;
 
-    if (msg_id != UINT32_MAX && message_filter.size() > 0 && message_filter.find(msg_id) == message_filter.end()) {
+    if (msg_id != UINT32_MAX && 
+        _message_filter.size() > 0 && 
+        std::find(_message_filter.begin(), _message_filter.end(), msg_id) == _message_filter.end()) {
+
         // if filter is defined and message is not in the set then discard it
         return false;
     }

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -20,7 +20,6 @@
 #include <mavlink.h>
 
 #include <memory>
-#include <set>
 #include <vector>
 
 #include "comm.h"
@@ -99,7 +98,7 @@ public:
 
     bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
 
-    void add_message_to_filter(uint32_t msg_id) { message_filter.insert(msg_id); }
+    void add_message_to_filter(uint32_t msg_id) { _message_filter.push_back(msg_id); }
 
     struct buffer rx_buf;
     struct buffer tx_buf;
@@ -136,7 +135,7 @@ protected:
     std::vector<uint16_t> _sys_comp_ids;
 
 private:
-    std::set<uint32_t> message_filter;
+    std::vector<uint32_t> _message_filter;
 };
 
 class UartEndpoint : public Endpoint {

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -20,6 +20,7 @@
 #include <mavlink.h>
 
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "comm.h"
@@ -96,14 +97,16 @@ public:
         return has_sys_comp_id(sys_comp_id);
     }
 
-    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid);
+    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
+
+    void add_message_to_filter(uint32_t msg_id) { message_filter.insert(msg_id); }
 
     struct buffer rx_buf;
     struct buffer tx_buf;
 
 protected:
     virtual int read_msg(struct buffer *pbuf, int *target_system, int *target_compid,
-                         uint8_t *src_sysid, uint8_t *src_compid);
+                         uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id);
     virtual ssize_t _read_msg(uint8_t *buf, size_t len) = 0;
     bool _check_crc(const mavlink_msg_entry_t *msg_entry);
     void _add_sys_comp_id(uint16_t sys_comp_id);
@@ -131,6 +134,9 @@ protected:
     const bool _crc_check_enabled;
     uint32_t _incomplete_msgs = 0;
     std::vector<uint16_t> _sys_comp_ids;
+
+private:
+    std::set<uint32_t> message_filter;
 };
 
 class UartEndpoint : public Endpoint {
@@ -147,7 +153,7 @@ public:
 
 protected:
     int read_msg(struct buffer *pbuf, int *target_system, int *target_compid, uint8_t *src_sysid,
-                 uint8_t *src_compid) override;
+                 uint8_t *src_compid, uint32_t *msg_id) override;
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
 private:

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -215,7 +215,7 @@ static int add_endpoint_address(const char *name, size_t name_len, const char *i
     conf->type = Udp;
     conf->port = ULONG_MAX;
 
-    if (name) {
+    if (!conf->name && name) {
         conf->name = strndup(name, name_len);
         if (!conf->name) {
             ret = -ENOMEM;
@@ -224,16 +224,19 @@ static int add_endpoint_address(const char *name, size_t name_len, const char *i
     }
 
     if (ip) {
+        free(conf->address);
         conf->address = strdup(ip);
         if (!conf->address) {
             ret = -ENOMEM;
             goto fail;
         }
-    } else {
+    }
+
+    if (!conf->address) {
         ret = -EINVAL;
         goto fail;
     }
-
+    
     if (filter) {
         conf->filter = strdup(filter);
         if (!conf->filter) {

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -132,12 +132,12 @@ int Mainloop::write_msg(Endpoint *e, const struct buffer *buf)
 }
 
 void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
-                         int sender_compid)
+                         int sender_compid, uint32_t msg_id)
 {
     bool unknown = true;
 
     for (Endpoint **e = g_endpoints; *e != nullptr; e++) {
-        if ((*e)->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid)) {
+        if ((*e)->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
             log_debug("Endpoint [%d] accepted message to %d/%d from %u/%u", (*e)->fd, target_sysid,
                       target_compid, sender_sysid, sender_compid);
             write_msg(*e, buf);
@@ -146,7 +146,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
     }
 
     for (struct endpoint_entry *e = g_tcp_endpoints; e; e = e->next) {
-        if (e->endpoint->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid)) {
+        if (e->endpoint->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
             log_debug("Endpoint [%d] accepted message to %d/%d from %u/%u", e->endpoint->fd,
                       target_sysid, target_compid, sender_sysid, sender_compid);
             int r = write_msg(e->endpoint, buf);
@@ -399,6 +399,14 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
             if (udp->open(conf->address, conf->port, conf->eavesdropping) < 0) {
                 log_error("Could not open %s:%ld", conf->address, conf->port);
                 return false;
+            }
+
+            if (conf->filter) {
+                char *token = strtok(conf->filter, ",");
+                while (token != NULL) {
+                    udp->add_message_to_filter(atoi(token));
+                    token = strtok(NULL, ",");
+                } 
             }
 
             g_endpoints[i] = udp.release();

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -36,7 +36,7 @@ public:
     int remove_fd(int fd);
     void loop();
     void route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
-                   int sender_compid);
+                   int sender_compid, uint32_t msg_id = UINT32_MAX);
     void handle_read(Endpoint *e);
     void handle_canwrite(Endpoint *e);
     void handle_tcp_connection();
@@ -117,6 +117,7 @@ struct endpoint_config {
             bool flowcontrol;
         };
     };
+    char *filter;
 };
 
 struct options {

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -191,7 +191,7 @@ int ULog::write_msg(const struct buffer *buffer)
         mavlink_msg_logging_ack_encode(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, &ack);
         _send_msg(&msg, _target_system_id);
         /* message will be handled by MAVLINK_MSG_ID_LOGGING_DATA case */
-        /* fall through */
+        [[gnu::fallthrough]];
     }
     case MAVLINK_MSG_ID_LOGGING_DATA: {
         if (trimmed_zeros) {

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -191,7 +191,7 @@ int ULog::write_msg(const struct buffer *buffer)
         mavlink_msg_logging_ack_encode(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, &ack);
         _send_msg(&msg, _target_system_id);
         /* message will be handled by MAVLINK_MSG_ID_LOGGING_DATA case */
-        [[gnu::fallthrough]];
+        /* fall through */
     }
     case MAVLINK_MSG_ID_LOGGING_DATA: {
         if (trimmed_zeros) {


### PR DESCRIPTION
Add Filter field to endpoint configuration to limit the messages that are sent to particular endpoint and improve performance.
For example XYZ is interested only in messages 24,33,76,320,321,323.
This configuration filters all other messages so that they're not sent to XYZ and don't need to be parsed.

[UdpEndpoint XYZ]
Mode = Normal
Address = 127.0.0.1
Port = 14530
Filter = 24,33,76,320,321,323
