### PR TITLE
logendpoint: mark unfinished logs as read-only on startup

### DIFF
--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -48,6 +48,13 @@ public:
     virtual bool start();
     virtual void stop();
 
+    /**
+     * Check existing log files and mark logs as read-only if needed.
+     * This handles the case where the system (or mavlink-router) crashed or
+     * lost power.
+     */
+    void mark_unfinished_logs();
+
 protected:
     const char *_logs_dir;
     int _target_system_id = -1;

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -441,6 +441,7 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
         } else {
             _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode);
         }
+        _log_endpoint->mark_unfinished_logs();
         g_endpoints[i] = _log_endpoint;
     }
 


### PR DESCRIPTION
If the system or mavlink-router crashed, the last log was not marked as read-only, so we go through all logs on startup and check them.