### PR TITLE
Add sleep mode for endpoints

### DIFF
--- a/examples/config.sample
+++ b/examples/config.sample
@@ -82,6 +82,13 @@
 #       Default value: Increasing value, starting from 14550, when
 #       mode is `Normal`. Must be defined if on `Eavesdropping` mode.
 #
+#   SleepInterval
+#       Numeric value defining how many seconds endpoint will wait for
+#       a new message until it switches to the sleep mode. In the sleep
+#       mode all the message to the endpoint will be discarded. Any
+#       message from the endpoint will wake up the endpoint.
+#       Default value: 0 s (sleep mode is disabled).
+#
 # Section [TcpEndpoint]: This section must have a name
 #
 # Keys:

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -44,9 +44,12 @@
 
 #define UART_BAUD_RETRY_SEC 5
 
-Endpoint::Endpoint(const char *name, bool crc_check_enabled)
+Endpoint::Endpoint(const char *name, bool crc_check_enabled, unsigned long sleep_interval)
     : _name{name}
     , _crc_check_enabled{crc_check_enabled}
+    , _sleep_interval{sleep_interval}
+    // No need to initialize the last message timestamp (sleep mode is enabled initially)
+    , _sleep_enabled{static_cast<bool>(sleep_interval)}
 {
     rx_buf.data = (uint8_t *) malloc(RX_BUF_MAX_SIZE);
     rx_buf.len = 0;
@@ -282,6 +285,17 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
     pbuf->data = rx_buf.data;
     pbuf->len = expected_size;
 
+    if ((msg_entry != nullptr) && _sleep_interval) {
+        if (_sleep_enabled) {
+            log_warning("Endpoint \"%s\" is now awake", _name);
+            _sleep_enabled = false;
+        }
+
+        // Update the last message timestamp
+        if (clock_gettime(CLOCK_MONOTONIC, &_last_message) < 0)
+            log_error("Failed to get the current time: \"%s\"", strerror(errno));  
+    }
+
     return msg_entry != nullptr ? ReadOk : ReadUnkownMsg;
 }
 
@@ -335,6 +349,28 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
 
         // if filter is defined and message is not in the set then discard it
         return false;
+    }
+
+    if (_sleep_interval) {
+        if (_sleep_enabled)
+            // Discard the message if the endpoint is in the sleep mode
+            return false;
+        else {
+            struct timespec current_time;
+
+            if (clock_gettime(CLOCK_MONOTONIC, &current_time) < 0)
+                log_error("Failed to get the current time: \"%s\"", strerror(errno));
+
+            if (((current_time.tv_sec + current_time.tv_nsec / 1000000000.0) - 
+                    (_last_message.tv_sec + _last_message.tv_nsec / 1000000000.0)) > _sleep_interval) {
+                log_warning("Endpoint \"%s\" is now sleeping", _name);
+
+                _sleep_enabled = true;
+
+                // Discard the message, endpoint is in the sleep mode now
+                return false;
+            }
+        }
     }
 
     // Message is broadcast on sysid: accept msg
@@ -398,6 +434,7 @@ void Endpoint::print_statistics()
     printf("\n\t}");
     printf("\n\tTransmitted messages {");
     printf("\n\t\tTotal: %u %luKBytes", _stat.write.total, _stat.write.bytes / 1000);
+    printf("\n\tSleep mode: %s", (_sleep_enabled) ? "enabled" : "disabled");
     printf("\n\t}");
     printf("\n}\n");
 }
@@ -678,8 +715,8 @@ int UartEndpoint::add_speeds(std::vector<unsigned long> bauds)
     return 0;
 }
 
-UdpEndpoint::UdpEndpoint()
-    : Endpoint{"UDP", false}
+UdpEndpoint::UdpEndpoint(unsigned long sleep_interval)
+    : Endpoint{"UDP", false, sleep_interval}
 {
     bzero(&sockaddr, sizeof(sockaddr));
 }
@@ -716,7 +753,8 @@ int UdpEndpoint::open(const char *ip, unsigned long port, bool to_bind)
 
     if (to_bind)
         sockaddr.sin_port = 0;
-    log_info("Open UDP [%d] %s:%lu %c", fd, ip, port, to_bind ? '*' : ' ');
+    log_info("Open UDP [%d] %s:%lu %c %s", fd, ip, port, to_bind ? '*' : ' ',
+        (_sleep_interval) ? "S" : "");
 
     return fd;
 
@@ -781,7 +819,7 @@ int UdpEndpoint::write_msg(const struct buffer *pbuf)
 }
 
 TcpEndpoint::TcpEndpoint()
-    : Endpoint{"TCP", false}
+    : Endpoint{"TCP", false, 0}
 {
     bzero(&sockaddr, sizeof(sockaddr));
 }

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -75,7 +75,7 @@ public:
         ReadUnkownMsg,
     };
 
-    Endpoint(const char *name, bool crc_check_enabled);
+    Endpoint(const char *name, bool crc_check_enabled, unsigned long sleep_interval);
     virtual ~Endpoint();
 
     int handle_read() override;
@@ -134,13 +134,18 @@ protected:
     uint32_t _incomplete_msgs = 0;
     std::vector<uint16_t> _sys_comp_ids;
 
+    unsigned long _sleep_interval;
+
 private:
     std::vector<uint32_t> _message_filter;
+
+    bool _sleep_enabled;
+    struct timespec _last_message;  // Last message timestamp
 };
 
 class UartEndpoint : public Endpoint {
 public:
-    UartEndpoint() : Endpoint{"UART", true} { }
+    UartEndpoint() : Endpoint{"UART", true, 0} { }
     virtual ~UartEndpoint();
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
@@ -165,7 +170,7 @@ private:
 
 class UdpEndpoint : public Endpoint {
 public:
-    UdpEndpoint();
+    UdpEndpoint(unsigned long sleep_interval);
     virtual ~UdpEndpoint() { }
 
     int write_msg(const struct buffer *pbuf) override;

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -37,7 +37,7 @@ enum class LogMode {
 class LogEndpoint : public Endpoint {
 public:
     LogEndpoint(const char *name, const char *logs_dir, LogMode mode)
-        : Endpoint{name, false}
+        : Endpoint{name, false, 0}
         , _logs_dir{logs_dir}
         , _mode(mode)
     {

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -205,7 +205,8 @@ fail:
 }
 
 static int add_endpoint_address(const char *name, size_t name_len, const char *ip,
-                                long unsigned port, bool eavesdropping, const char *filter)
+                                long unsigned port, bool eavesdropping, const char *filter,
+                                long unsigned sleep_interval)
 {
     int ret;
 
@@ -244,6 +245,8 @@ static int add_endpoint_address(const char *name, size_t name_len, const char *i
             goto fail;
         }
     }
+
+    conf->sleep_interval = sleep_interval;
 
     if (port != ULONG_MAX) {
         conf->port = port;
@@ -410,7 +413,7 @@ static int parse_argv(int argc, char *argv[])
                 return -EINVAL;
             }
 
-            add_endpoint_address(NULL, 0, ip, port, false, NULL);
+            add_endpoint_address(NULL, 0, ip, port, false, NULL, 0);
             free(ip);
             break;
         }
@@ -496,7 +499,7 @@ static int parse_argv(int argc, char *argv[])
                 return -EINVAL;
             }
 
-            add_endpoint_address(NULL, 0, base, number, true, NULL);
+            add_endpoint_address(NULL, 0, base, number, true, NULL, 0);
         } else {
             const char *bauds = number != ULONG_MAX ? base + strlen(base) + 1 : NULL;
             int ret = add_uart_endpoint(NULL, 0, base, bauds, false);
@@ -676,12 +679,14 @@ static int parse_confs(ConfFile &conf)
         bool eavesdropping;
         unsigned long port;
         char *filter;
+        unsigned long sleep_interval;
     };
     static const ConfFile::OptionsTable option_table_udp[] = {
-        {"address", true,   ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, addr)},
-        {"mode",    true,   parse_mode,                 OPTIONS_TABLE_STRUCT_FIELD(option_udp, eavesdropping)},
-        {"port",    false,  ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_udp, port)},
-        {"filter",  false,  ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, filter)},
+        {"address",         true,   ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, addr)},
+        {"mode",            true,   parse_mode,                 OPTIONS_TABLE_STRUCT_FIELD(option_udp, eavesdropping)},
+        {"port",            false,  ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_udp, port)},
+        {"filter",          false,  ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, filter)},
+        {"SleepInterval",   false,  ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_udp, sleep_interval)}
     };
 
     struct option_tcp {
@@ -727,7 +732,8 @@ static int parse_confs(ConfFile &conf)
                 ret = -EINVAL;
             } else {
                 ret = add_endpoint_address(iter.name + offset, iter.name_len - offset, opt_udp.addr,
-                                           opt_udp.port, opt_udp.eavesdropping, opt_udp.filter);
+                                           opt_udp.port, opt_udp.eavesdropping, opt_udp.filter,
+                                           opt_udp.sleep_interval);
             }
         }
 

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -395,7 +395,7 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
             break;
         }
         case Udp: {
-            std::unique_ptr<UdpEndpoint> udp{new UdpEndpoint{}};
+            std::unique_ptr<UdpEndpoint> udp{new UdpEndpoint{conf->sleep_interval}};
             if (udp->open(conf->address, conf->port, conf->eavesdropping) < 0) {
                 log_error("Could not open %s:%ld", conf->address, conf->port);
                 return false;

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -118,6 +118,7 @@ struct endpoint_config {
         };
     };
     char *filter;
+    unsigned long sleep_interval;
 };
 
 struct options {


### PR DESCRIPTION
Frequently LTE connection has a limited traffic volume. In this case it's very useful to drop all outcoming MAVLink messages on some endpoints while there are no clients on the other side.