### PR TITLE
LogEndpoint: call fsync() once per second

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -124,7 +124,8 @@ AM_CXXFLAGS = \
 AM_LDFLAGS = \
 	-Wl,--as-needed \
 	-Wl,--no-undefined \
-	-Wl,--gc-sections
+	-Wl,--gc-sections \
+	-lrt
 
 bin_PROGRAMS += mavlink-routerd
 mavlink_routerd_SOURCES = \

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -38,6 +38,22 @@
 #define ALIVE_TIMEOUT 5
 #define MAX_RETRIES 10
 
+LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode)
+    : Endpoint {name, false}
+    , _logs_dir {logs_dir}
+    , _mode(mode)
+{
+    assert(_logs_dir);
+    _add_sys_comp_id(LOG_ENDPOINT_SYSTEM_ID << 8);
+    _fsync_cb.aio_fildes = -1;
+
+    aioinit aio_init_data {};
+    aio_init_data.aio_threads = 1;
+    aio_init_data.aio_num = 1;
+    aio_init_data.aio_idle_time = 3; // make sure to keep the thread running
+    aio_init(&aio_init_data);
+}
+
 void LogEndpoint::_send_msg(const mavlink_message_t *msg, int target_sysid)
 {
     uint8_t data[MAVLINK_MAX_PACKET_LEN];
@@ -95,6 +111,7 @@ int LogEndpoint::_get_file(const char *extension)
     uint32_t i;
     int j, r;
     DIR *dir;
+    int dir_fd;
 
     dir = _open_or_create_dir(_logs_dir);
     if (!dir) {
@@ -105,6 +122,7 @@ int LogEndpoint::_get_file(const char *extension)
     std::shared_ptr<void> defer(dir, [](DIR *p) { closedir(p); });
 
     i = _get_prefix(dir);
+    dir_fd = dirfd(dir);
 
     for (j = 0; j <= MAX_RETRIES; j++) {
         r = snprintf(_filename, sizeof(_filename), "%05u-%i-%02i-%02i_%02i-%02i-%02i.%s", i + j,
@@ -116,14 +134,18 @@ int LogEndpoint::_get_file(const char *extension)
             return -1;
         }
 
-        r = openat(dirfd(dir), _filename, O_WRONLY | O_CLOEXEC | O_CREAT | O_NONBLOCK | O_EXCL,
-                   0644);
+        r = openat(dir_fd, _filename, O_WRONLY | O_CLOEXEC | O_CREAT | O_NONBLOCK | O_EXCL, 0644);
         if (r < 0) {
             if (errno != EEXIST) {
                 log_error("Unable to open Log file(%s): (%m)", _filename);
                 return -1;
             }
             continue;
+        }
+
+        // Ensure the directory entry of the file is written to disk
+        if (fsync(dir_fd) == -1) {
+            log_error("fsync failed: %m");
         }
 
         return r;
@@ -146,9 +168,15 @@ void LogEndpoint::stop()
         _alive_check_timeout = nullptr;
     }
 
+    if (_fsync_timeout) {
+        mainloop.del_timeout(_fsync_timeout);
+        _fsync_timeout = nullptr;
+    }
+
     fsync(_file);
     close(_file);
     _file = -1;
+    _fsync_cb.aio_fildes = -1;
 
     // change file permissions to read-only to mark them as finished
     char log_file[PATH_MAX];
@@ -177,11 +205,24 @@ bool LogEndpoint::start()
         goto timeout_error;
     }
 
+    // Call fsync once per second
+    _fsync_timeout = Mainloop::get_instance().add_timeout(
+        MSEC_PER_SEC, std::bind(&LogEndpoint::_fsync, this), this);
+    if (!_fsync_timeout) {
+        log_error("Unable to add timeout");
+        goto timeout_error;
+    }
+
     log_info("Logging target system_id=%u on %s", _target_system_id, _filename);
 
     return true;
 
 timeout_error:
+    if (_logging_start_timeout) {
+        Mainloop::get_instance().del_timeout(_fsync_timeout);
+        _fsync_timeout = nullptr;
+    }
+
     close(_file);
     _file = -1;
     return false;
@@ -196,6 +237,24 @@ bool LogEndpoint::_alive_timeout()
     }
 
     _timeout_write_total = _stat.write.total;
+    return true;
+}
+
+bool LogEndpoint::_fsync()
+{
+    if (_file < 0) {
+        return false;
+    }
+
+    if (_fsync_cb.aio_fildes >= 0 && aio_error(&_fsync_cb) == EINPROGRESS) {
+        // previous operation is still in progress
+        return true;
+    }
+    _fsync_cb.aio_fildes = _file;
+    _fsync_cb.aio_sigevent.sigev_notify = SIGEV_NONE;
+
+    aio_fsync(O_SYNC, &_fsync_cb);
+
     return true;
 }
 

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <aio.h>
 #include <assert.h>
 #include <dirent.h>
 
@@ -36,14 +37,7 @@ enum class LogMode {
 
 class LogEndpoint : public Endpoint {
 public:
-    LogEndpoint(const char *name, const char *logs_dir, LogMode mode)
-        : Endpoint{name, false}
-        , _logs_dir{logs_dir}
-        , _mode(mode)
-    {
-        assert(_logs_dir);
-        _add_sys_comp_id(LOG_ENDPOINT_SYSTEM_ID << 8);
-    }
+    LogEndpoint(const char *name, const char *logs_dir, LogMode mode);
 
     virtual bool start();
     virtual void stop();
@@ -55,8 +49,10 @@ protected:
     LogMode _mode;
 
     Timeout *_logging_start_timeout = nullptr;
+    Timeout *_fsync_timeout = nullptr;
     Timeout *_alive_check_timeout = nullptr;
     uint32_t _timeout_write_total = 0;
+    aiocb _fsync_cb = {};
 
     virtual const char *_get_logfile_extension() = 0;
 
@@ -66,6 +62,8 @@ protected:
 
     virtual bool _start_timeout() = 0;
     virtual bool _alive_timeout();
+
+    bool _fsync();
 
     void _handle_auto_start_stop(uint32_t msg_id, uint8_t source_system_id,
             uint8_t source_component_id, uint8_t *payload);


### PR DESCRIPTION
With the default kernel settings (/proc/sys/vm/dirty_expire_centisecs = 3000), it is possible to lose up to 30s of logging data in events of power loss.
This patch reduces worst-case loss to 1s by calling fsync() every second.