### PR TITLE
Automatic log deletion as storage space fills up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ tags
 /heartbeat-print
 
 test.log
+
+# Jetbrains IDEs
+.idea/
+compile_commands.json

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -37,6 +37,16 @@
 #       If set to while-armed, a new log file is created whenever the vehicle is
 #       armed, and closed when disarmed.
 #
+#   MinFreeSpace
+#       The Log Endpoint will delete old log files until there are MinFreeSpace bytes
+#       available on the storage device of the logs. Set to 0 to ignore this limit.
+#       Default: 0 (disabled)
+#
+#   MaxLogFiles
+#       Maximum number of log files to keep. The Log Endpoint will delete old
+#       log files to keep the total below this number. Set to 0 to ignore this limit.
+#       Default: 0 (disabled)
+#
 #   DebugLogLevel
 #       One of <error>, <warning>, <info> or <debug>. Which debug log
 #       level is being used by mavlink-router, with <debug> being the

--- a/src/mavlink-router/autolog.cpp
+++ b/src/mavlink-router/autolog.cpp
@@ -65,9 +65,11 @@ int AutoLog::write_msg(const struct buffer *buffer)
     /* We check autopilot on heartbeat */
     log_debug("Got autopilot %u from heartbeat", heartbeat->autopilot);
     if (heartbeat->autopilot == MAV_AUTOPILOT_PX4) {
-        _logger = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir, _mode));
+        _logger
+            = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir, _mode, _min_free_space, _max_files));
     } else if (heartbeat->autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-        _logger = std::unique_ptr<LogEndpoint>(new BinLog(_logs_dir, _mode));
+        _logger = std::unique_ptr<LogEndpoint>(
+            new BinLog(_logs_dir, _mode, _min_free_space, _max_files));
     } else {
         log_warning("Unidentified autopilot, cannot start flight stack logging");
     }

--- a/src/mavlink-router/autolog.h
+++ b/src/mavlink-router/autolog.h
@@ -24,9 +24,9 @@
 
 class AutoLog : public LogEndpoint {
 public:
-
-    AutoLog(const char *logs_dir, LogMode mode)
-        : LogEndpoint{"AutoLog", logs_dir, mode}
+    AutoLog(const char *logs_dir, LogMode mode, unsigned long min_free_space,
+            unsigned long max_files)
+        : LogEndpoint{"AutoLog", logs_dir, mode, min_free_space, max_files}
     {
     }
 

--- a/src/mavlink-router/binlog.h
+++ b/src/mavlink-router/binlog.h
@@ -24,8 +24,9 @@
 
 class BinLog : public LogEndpoint {
 public:
-    BinLog(const char *logs_dir, LogMode mode)
-        : LogEndpoint{"BinLog", logs_dir, mode}
+    BinLog(const char *logs_dir, LogMode mode, unsigned long min_free_space,
+           unsigned long max_files)
+        : LogEndpoint{"BinLog", logs_dir, mode, min_free_space, max_files}
     {
     }
 

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -24,11 +24,16 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <map>
 #include <memory>
+#include <tuple>
+#include <vector>
 
 #include <common/log.h>
 #include <common/util.h>
@@ -38,9 +43,12 @@
 #define ALIVE_TIMEOUT 5
 #define MAX_RETRIES 10
 
-LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode)
-    : Endpoint {name}
-    , _logs_dir {logs_dir}
+LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode,
+                         unsigned long min_free_space, unsigned long max_files)
+    : Endpoint{name}
+    , _logs_dir{logs_dir}
+    , _min_free_space(min_free_space)
+    , _max_files(max_files)
     , _mode(mode)
 {
     assert(_logs_dir);
@@ -100,6 +108,110 @@ void LogEndpoint::mark_unfinished_logs()
             chmod(log_file, S_IRUSR | S_IRGRP | S_IROTH);
         }
     }
+    closedir(dir);
+}
+
+void LogEndpoint::_delete_old_logs()
+{
+
+    struct statvfs buf;
+    uint64_t free_space;
+    if (statvfs(_logs_dir, &buf) == 0) {
+        free_space = (uint64_t) buf.f_bsize * buf.f_bavail;
+    } else {
+        free_space = UINT64_MAX;
+        log_error("[Log Deletion] Error when measuring free disk space: %m");
+    }
+    log_debug("[Log Deletion]  Total free space: %lumb. Min free space: %lumb",
+              free_space / (1ul << 20), _min_free_space / (1ul << 20));
+
+    // This check is not necessary, it just saves on some file IO.
+    if (free_space > _min_free_space && _max_files == 0) {
+        return;
+    }
+
+    DIR *dir = opendir(_logs_dir);
+
+    // Assume the directory does not exist if opendir failed
+    if (!dir) {
+        return;
+    }
+
+    int dir_fd = dirfd(dir);
+    if (dir_fd < 0) {
+        closedir(dir);
+        log_error("[Log Deletion] Error getting dir file descriptor: %m");
+        return;
+    }
+
+    // Map of index -> (filename, file size)
+    // All three of these values are saved for later to reduce the amount of IO operations needed.
+    std::map<unsigned long, std::tuple<std::string, unsigned long>> file_map;
+
+    struct dirent *ent;
+    uint32_t idx, year, month, day, hour, minute, second;
+
+    // This loop just gathers the name, index, and size of each read-only file in the log dir
+    while ((ent = readdir(dir)) != nullptr) {
+        // Even though we don't need the timestamp, we want to match as much of the filename as
+        // possible, so we don't accidentally delete something that isn't a log.
+        if (sscanf(ent->d_name, "%u-%u-%u-%u_%u-%u-%u.", &idx, &year, &month, &day, &hour, &minute,
+                   &second)
+            == 7) {
+            struct stat file_stat;
+            if (!fstatat(dir_fd, ent->d_name, &file_stat, 0)) {
+                // Only bother with read-only files. If this function is somehow called while a file
+                // is still being used (not read-only), it should not be deleted.
+                if (!S_ISDIR(file_stat.st_mode) && !(file_stat.st_mode & S_IWUSR)) {
+                    std::string str(ent->d_name);
+                    file_map[idx] = std::make_tuple(str, file_stat.st_size);
+                }
+            }
+        }
+    }
+
+    // If the configured value for _min_free_space is 0, then we don't have to do anything special.
+    uint64_t bytes_to_delete = _min_free_space - free_space;
+    // If the configured value for _max_files is 0, then set this to -1 to indicate that we've
+    // already deleted enough files.
+    uint64_t files_to_delete = _max_files > 0 ? file_map.size() - _max_files : -1;
+
+    log_debug("[Log Deletion] Files to delete: %ld", files_to_delete);
+
+    // Delete the logs in order until there's enough free space, and few enough files
+    // It is possible for this loop to run only once and return immediately, if we don't actually
+    // need to delete any files. Maps in C++ are ordered by the keys, so this iteration is
+    // guaranteed to happen in index order (oldest -> newest)
+    for (auto &pair : file_map) {
+        if (bytes_to_delete <= 0 && files_to_delete <= 0) {
+            break;
+        }
+
+        std::string &filename = std::get<0>(pair.second);
+        const unsigned long filesize = std::get<1>(pair.second);
+        char log_file[PATH_MAX];
+        if (snprintf(log_file, sizeof(log_file), "%s/%s", _logs_dir, filename.c_str())
+            >= (int)sizeof(log_file)) {
+            log_error("Directory + filename %s is longer than PATH_MAX of %d", filename.c_str(),
+                      PATH_MAX);
+            continue;
+        }
+
+        int err_code = remove(log_file);
+        if (err_code == 0) {
+            bytes_to_delete -= filesize;
+            files_to_delete--;
+            log_info("[Log Deletion] Deleted old logfile %s", filename.c_str());
+        } else {
+            log_error("[Log Deletion] Error deleting old logfile %s: %m", filename.c_str());
+        }
+    }
+
+    if (bytes_to_delete > 0) {
+        log_error(
+            "[Log Deletion] Deleted all closed logs, but there is still not enough free space.");
+    }
+
     closedir(dir);
 }
 
@@ -224,6 +336,9 @@ bool LogEndpoint::start()
         log_warning("Log already started");
         return false;
     }
+
+    // Clear up space before opening a new file
+    _delete_old_logs();
 
     _file = _get_file(_get_logfile_extension());
     if (_file < 0) {

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -37,7 +37,8 @@ enum class LogMode {
 
 class LogEndpoint : public Endpoint {
 public:
-    LogEndpoint(const char *name, const char *logs_dir, LogMode mode);
+    LogEndpoint(const char *name, const char *logs_dir, LogMode mode, unsigned long min_free_space,
+                unsigned long max_files);
 
     virtual bool start();
     virtual void stop();
@@ -53,6 +54,8 @@ protected:
     const char *_logs_dir;
     int _target_system_id = -1;
     int _file = -1;
+    unsigned long _min_free_space;
+    unsigned long _max_files;
     LogMode _mode;
 
     Timeout *_logging_start_timeout = nullptr;
@@ -79,6 +82,12 @@ private:
     int _get_file(const char *extension);
     uint32_t _get_prefix(DIR *dir);
     DIR *_open_or_create_dir(const char *name);
+
+    /**
+     * Delete old logs until a certain amount of free space and total number of log files are met.
+     * This can be configured using the .conf file, options MinFreeSpace and MaxLogFiles.
+     */
+    void _delete_old_logs();
 
     char _filename[64];
 };

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -40,15 +40,17 @@
 #define DEFAULT_RETRY_TCP_TIMEOUT 5
 
 static struct options opt = {
-        .endpoints = nullptr,
-        .conf_file_name = nullptr,
-        .conf_dir = nullptr,
-        .tcp_port = ULONG_MAX,
-        .report_msg_statistics = false,
-        .logs_dir = nullptr,
-        .log_mode = LogMode::always,
-        .debug_log_level = (int)Log::Level::INFO,
-        .mavlink_dialect = Auto
+    .endpoints = nullptr,
+    .conf_file_name = nullptr,
+    .conf_dir = nullptr,
+    .tcp_port = ULONG_MAX,
+    .report_msg_statistics = false,
+    .logs_dir = nullptr,
+    .log_mode = LogMode::always,
+    .debug_log_level = (int)Log::Level::INFO,
+    .mavlink_dialect = Auto,
+    .min_free_space = 0,
+    .max_log_files = 0,
 };
 
 static const struct option long_options[] = {
@@ -652,12 +654,19 @@ static int parse_confs(ConfFile &conf)
     const char *pattern;
 
     static const ConfFile::OptionsTable option_table[] = {
-        {"TcpServerPort",   false, ConfFile::parse_ul,      OPTIONS_TABLE_STRUCT_FIELD(options, tcp_port)},
-        {"ReportStats",     false, ConfFile::parse_bool,    OPTIONS_TABLE_STRUCT_FIELD(options, report_msg_statistics)},
-        {"MavlinkDialect",  false, parse_mavlink_dialect,   OPTIONS_TABLE_STRUCT_FIELD(options, mavlink_dialect)},
-        {"Log",             false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(options, logs_dir)},
-        {"LogMode",         false, parse_log_mode,          OPTIONS_TABLE_STRUCT_FIELD(options, log_mode)},
-        {"DebugLogLevel",   false, parse_log_level,         OPTIONS_TABLE_STRUCT_FIELD(options, debug_log_level)},
+        {"TcpServerPort", false, ConfFile::parse_ul, OPTIONS_TABLE_STRUCT_FIELD(options, tcp_port)},
+        {"ReportStats", false, ConfFile::parse_bool,
+         OPTIONS_TABLE_STRUCT_FIELD(options, report_msg_statistics)},
+        {"MavlinkDialect", false, parse_mavlink_dialect,
+         OPTIONS_TABLE_STRUCT_FIELD(options, mavlink_dialect)},
+        {"Log", false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(options, logs_dir)},
+        {"LogMode", false, parse_log_mode, OPTIONS_TABLE_STRUCT_FIELD(options, log_mode)},
+        {"DebugLogLevel", false, parse_log_level,
+         OPTIONS_TABLE_STRUCT_FIELD(options, debug_log_level)},
+        {"MinFreeSpace", false, ConfFile::parse_ul,
+         OPTIONS_TABLE_STRUCT_FIELD(options, min_free_space)},
+        {"MaxLogFiles", false, ConfFile::parse_ul,
+         OPTIONS_TABLE_STRUCT_FIELD(options, max_log_files)},
     };
 
     struct option_uart {

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -443,11 +443,14 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
 
     if (opt->logs_dir) {
         if (opt->mavlink_dialect == Ardupilotmega) {
-            _log_endpoint = new BinLog(opt->logs_dir, opt->log_mode);
+            _log_endpoint
+                = new BinLog(opt->logs_dir, opt->log_mode, opt->min_free_space, opt->max_log_files);
         } else if (opt->mavlink_dialect == Common) {
-            _log_endpoint = new ULog(opt->logs_dir, opt->log_mode);
+            _log_endpoint
+                = new ULog(opt->logs_dir, opt->log_mode, opt->min_free_space, opt->max_log_files);
         } else {
-            _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode);
+            _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode, opt->min_free_space,
+                                        opt->max_log_files);
         }
         _log_endpoint->mark_unfinished_logs();
         g_endpoints[i] = _log_endpoint;

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -130,4 +130,6 @@ struct options {
     LogMode log_mode;
     int debug_log_level;
     enum mavlink_dialect mavlink_dialect;
+    unsigned long min_free_space;
+    unsigned long max_log_files;
 };

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -23,8 +23,8 @@
 
 class ULog : public LogEndpoint {
 public:
-    ULog(const char *logs_dir, LogMode mode)
-        : LogEndpoint{"ULog", logs_dir, mode}
+    ULog(const char *logs_dir, LogMode mode, unsigned long min_free_space, unsigned long max_files)
+        : LogEndpoint{"ULog", logs_dir, mode, min_free_space, max_files}
     {
     }
 


### PR DESCRIPTION
Added two configuration options in the conf files: `MinFreeSpace` and `MaxLogFiles`. If there are less than `MinFreeSpace` bytes available on the device used for log storage, or if there are more than `MaxLogFiles` in the log directory, then files will be deleted. They are deleted in the order of their numerical index (the 5-digit number at the beginning of every log filename, before the timestamp), until both limits are met.

Both limits can be disabled by setting them to 0. 