### PR TITLE
Enable MAVLink CRC checks on UDP/TCP

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,7 @@ AllowShortBlocksOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 ColumnLimit: 100
 Cpp11BracedListStyle: true
+SpaceBeforeCpp11BracedList: false
 DerivePointerAlignment: false
 IndentCaseLabels: false
 Language: Cpp

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -75,7 +75,7 @@ public:
         ReadUnkownMsg,
     };
 
-    Endpoint(const char *name, bool crc_check_enabled);
+    Endpoint(const char *name);
     virtual ~Endpoint();
 
     int handle_read() override;
@@ -130,7 +130,6 @@ protected:
         } write;
     } _stat;
 
-    const bool _crc_check_enabled;
     uint32_t _incomplete_msgs = 0;
     std::vector<uint16_t> _sys_comp_ids;
 
@@ -140,7 +139,10 @@ private:
 
 class UartEndpoint : public Endpoint {
 public:
-    UartEndpoint() : Endpoint{"UART", true} { }
+    UartEndpoint()
+        : Endpoint {"UART"}
+    {
+    }
     virtual ~UartEndpoint();
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -39,7 +39,7 @@
 #define MAX_RETRIES 10
 
 LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode)
-    : Endpoint {name, false}
+    : Endpoint {name}
     , _logs_dir {logs_dir}
     , _mode(mode)
 {


### PR DESCRIPTION
UDP and TCP disabled MAVLink CRC checks because those protocols have
built-in CRC already. However there are several failure cases when relying
only on these:
- For the UDP case, if a UDP packet is not aligned with MAVLink messages,
  UDP packet drops or reorderings lead to corrupt MAVLink messages.
  For example some implementations fill up a fixed-size UDP packet.
- A connected component might just forward bytes that come from another
  (lossy) link. In my case it was a shared memory implementation
  translating to UDP, and the shared memory implementation
  dropped/had corrupt bytes.

These cases can lead to corrupt log files and even busy-loops of mavlink
router within the log processing.

An alternative would be to just ensure CRC is checked in the log classes.