### PR TITLE
LogEndpoint: call aio_fsync() once per second

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -124,7 +124,8 @@ AM_CXXFLAGS = \
 AM_LDFLAGS = \
 	-Wl,--as-needed \
 	-Wl,--no-undefined \
-	-Wl,--gc-sections
+	-Wl,--gc-sections \
+	-lrt
 
 bin_PROGRAMS += mavlink-routerd
 mavlink_routerd_SOURCES = \


### PR DESCRIPTION
With the default kernel settings (/proc/sys/vm/dirty_expire_centisecs
= 3000), it is possible to lose up to 30s of logging data in events of
power loss.
This patch reduces worst-case loss to 1s by calling fsync() every second.