### PR TITLE
Streamline some log outputs

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -313,6 +313,7 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
 {
     if (Log::get_max_level() >= Log::Level::DEBUG) {
         log_debug("Endpoint [%d] got message to %d/%d from %u/%u", fd, target_sysid, target_compid,
+        log_debug("Endpoint [%d] got message %u to %d/%d from %u/%u", fd, msg_id, target_sysid, target_compid,
                   src_sysid, src_compid);
         log_debug("\tKnown endpoints:");
         for (auto it = _sys_comp_ids.begin(); it != _sys_comp_ids.end(); it++) {

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -312,10 +312,9 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
                           uint8_t src_compid, uint32_t msg_id)
 {
     if (Log::get_max_level() >= Log::Level::DEBUG) {
-        log_debug("Endpoint [%d] got message to %d/%d from %u/%u", fd, target_sysid, target_compid,
         log_debug("Endpoint [%d] got message %u to %d/%d from %u/%u", fd, msg_id, target_sysid, target_compid,
                   src_sysid, src_compid);
-        log_debug("\tKnown endpoints:");
+        log_debug("\tKnown components:");
         for (auto it = _sys_comp_ids.begin(); it != _sys_comp_ids.end(); it++) {
             log_debug("\t\t%u/%u", (*it >> 8), *it & 0xff);
         }

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -644,7 +644,7 @@ int UartEndpoint::write_msg(const struct buffer *pbuf)
         log_debug("Discarding packet, incomplete write %zd but len=%u", r, pbuf->len);
     }
 
-    log_debug("UART: [%d] wrote %zd bytes", fd, r);
+    log_debug("UART [%d] wrote %zd bytes", fd, r);
 
     return r;
 }
@@ -762,7 +762,7 @@ int UdpEndpoint::write_msg(const struct buffer *pbuf)
         log_debug("Discarding packet, incomplete write %zd but len=%u", r, pbuf->len);
     }
 
-    log_debug("UDP: [%d] wrote %zd bytes", fd, r);
+    log_debug("UDP [%d] wrote %zd bytes", fd, r);
 
     return r;
 }
@@ -884,7 +884,7 @@ int TcpEndpoint::write_msg(const struct buffer *pbuf)
         log_debug("Discarding packet, incomplete write %zd but len=%u", r, pbuf->len);
     }
 
-    log_debug("TCP: [%d] wrote %zd bytes", fd, r);
+    log_debug("TCP [%d] wrote %zd bytes", fd, r);
 
     return r;
 }

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -120,7 +120,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
         if (r <= 0)
             return r;
 
-        log_debug("%s: Got %zd bytes [%d]", _name, r, fd);
+        log_debug("%s [%d] got %zd bytes", _name, fd, r);
         rx_buf.len += r;
     }
 

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -144,7 +144,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
 
     for (Endpoint **e = g_endpoints; *e != nullptr; e++) {
         if ((*e)->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
-            log_debug("Endpoint [%d] accepted message to %d/%d from %u/%u", (*e)->fd, target_sysid,
+            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", (*e)->fd, msg_id, target_sysid,
                       target_compid, sender_sysid, sender_compid);
             write_msg(*e, buf);
             unknown = false;
@@ -153,7 +153,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
 
     for (struct endpoint_entry *e = g_tcp_endpoints; e; e = e->next) {
         if (e->endpoint->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
-            log_debug("Endpoint [%d] accepted message to %d/%d from %u/%u", e->endpoint->fd,
+            log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", e->endpoint->fd, msg_id,
                       target_sysid, target_compid, sender_sysid, sender_compid);
             int r = write_msg(e->endpoint, buf);
             if (r == -EPIPE) {
@@ -165,7 +165,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
 
     if (unknown) {
         _errors_aggregate.msg_to_unknown++;
-        log_debug("Message to unknown sysid/compid: %u/%u", target_sysid, target_compid);
+        log_debug("Message %u to unknown sysid/compid: %u/%u", msg_id, target_sysid, target_compid);
     }
 }
 


### PR DESCRIPTION
this PR is NFC. 

It modifies the log output to the console in some few places, to make it more consistent and symmetric. This makes the output not only better to read but also makes doing greeps, searches and such things easier and more effective. ;)

It also displays the msg id in some places for better identification of whats going on. 

It replaces "known endpoints" with "known components", since this is what is displayed.

:):)