### PR TITLE
Remove GNU-specific aio_init() function for musl compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,8 @@ LT_INIT([disable-static pic-only])
 # Function and structure checks
 #####################################################################
 
+AC_CHECK_DECLS([aio_init], [], [], [#include <aio.h>])
+
 AC_MSG_CHECKING([whether _Static_assert() is supported])
 AC_COMPILE_IFELSE(
 	[AC_LANG_SOURCE([[_Static_assert(1, "Test");]])],

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -55,11 +55,13 @@ LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode,
     _add_sys_comp_id(LOG_ENDPOINT_SYSTEM_ID << 8);
     _fsync_cb.aio_fildes = -1;
 
+#if HAVE_DECL_AIO_INIT
     aioinit aio_init_data {};
     aio_init_data.aio_threads = 1;
     aio_init_data.aio_num = 1;
     aio_init_data.aio_idle_time = 3; // make sure to keep the thread running
     aio_init(&aio_init_data);
+#endif
 }
 
 void LogEndpoint::_send_msg(const mavlink_message_t *msg, int target_sysid)


### PR DESCRIPTION
`aio_init()` is GNU-specific, and not compatible with musl. Is there a reason for having those lines (i.e. has it been proven that this is useful), or can they be removed?

They are all that's needed to be fixed to support musl again.