### PR TITLE
fix reuse of r loop variable for p->handle_read

### DIFF
--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -282,8 +282,8 @@ void Mainloop::loop()
             Pollable *p = static_cast<Pollable *>(events[i].data.ptr);
 
             if (events[i].events & EPOLLIN) {
-                r = p->handle_read();
-                if (r < 0 && !p->is_valid()) {
+              int rd = p->handle_read();
+                if (rd < 0 && !p->is_valid()) {
                     // Only TcpEndpoint may become invalid after a read
                     should_process_tcp_hangups = true;
                 }


### PR DESCRIPTION
r the number of polled events is changed if there is a readable event EPOLLIN 
Changed to a local temporary variable rd.