### PR TITLE
Enable IPv6 Addresses and add Input Validation for IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ be disabled with --disable-systemd. The default systemd system directory
 is taken via pkg-config. To use another directory update the above
 path, use --with-systemdsystemunitdir.
 
+By default mavlink-router is capable of using IPv6 addresses. In a system without an IPv6
+capable kernel, this can be disabled with --disable-ipv6.
+
 Installation location can be changed using the --prefix option while configuring.
 
 Build:
@@ -80,6 +83,9 @@ It's also possible to route mavlinks packets from any interface using:
 
 mavlink-router also listens, by default, on port 5760 for TCP connections. Any
 connection there will also receive routed packets.
+
+IPv6 addresses must be enclosed in square brackets like this: `[::1]`. The port number
+can be specified in the same way, as with IPv4 then: `[::1]:14550`.
 
 <a name="Conffiles"></a>
 ### Conf file ###

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,12 @@ AC_ARG_ENABLE(systemd, AC_HELP_STRING([--disable-systemd],
 		[disable systemd integration]), [enable_systemd=${enableval}])
 AM_CONDITIONAL(SYSTEMD, test "${enable_systemd}" != "no")
 
+AC_ARG_ENABLE(enable_ipv6, AC_HELP_STRING([--disable-ipv6],
+		[disable IPv6 capability]), [enable_ipv6=${enableval}])
+if (test "${enable_ipv6}" != "no"); then
+	AC_DEFINE([ENABLE_IPV6], [], [Enable IPv6])
+fi
+
 #####################################################################
 # Default CFLAGS and LDFLAGS
 #####################################################################

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -79,7 +79,8 @@
 #       IP of interface to which mavlink-router will listen for
 #       incoming packets. In this case, `0.0.0.0` means that
 #       mavlink-router will listen on all interfaces.
-#       No dafault value. Must be defined.
+#       IPv6 addresses must be enclosed in square brackets.
+#       No default value. Must be defined.
 #
 #   Mode
 #       One of <normal> or <eavesdropping>. See `Address` for more
@@ -97,6 +98,7 @@
 # Keys:
 #   Address:
 #       IP to which mavlink-router will connect to.
+#       IPv6 addresses must be enclosed in square brackets.
 #       No default value. Must be defined.
 #
 #   Port:

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -101,7 +101,7 @@
 #
 #   Port:
 #       Numeric value with port to which mavlink-router will connect to.
-#       No dafault value. Must be defined.
+#       No default value. Must be defined.
 #
 #   RetryTimeout:
 #       Numeric value defining how many seconds mavlink-router should wait

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -110,6 +110,12 @@ protected:
     bool _check_crc(const mavlink_msg_entry_t *msg_entry);
     void _add_sys_comp_id(uint16_t sys_comp_id);
 
+#ifdef ENABLE_IPV6
+    static bool is_ipv6(const char *ip);
+    static bool ipv6_is_linklocal(const char *ip);
+    static unsigned int ipv6_get_scope_id(const char *ip);
+#endif
+
     const char *_name;
     size_t _last_packet_len = 0;
 
@@ -176,6 +182,10 @@ public:
     int open(const char *ip, unsigned long port, bool bind = false);
 
     struct sockaddr_in sockaddr;
+#ifdef ENABLE_IPV6
+    struct sockaddr_in6 sockaddr6;
+    bool is_ipv6;
+#endif
 
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
@@ -194,6 +204,10 @@ public:
     int flush_pending_msgs() override { return -ENOSYS; }
 
     struct sockaddr_in sockaddr;
+#ifdef ENABLE_IPV6
+    struct sockaddr_in6 sockaddr6;
+    bool is_ipv6;
+#endif
     int retry_timeout = 0;
 
     inline const char *get_ip() {

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -113,6 +113,7 @@ protected:
 #ifdef ENABLE_IPV6
     static bool is_ipv6(const char *ip);
     static bool ipv6_is_linklocal(const char *ip);
+    static bool ipv6_is_multicast(const char *ip);
     static unsigned int ipv6_get_scope_id(const char *ip);
 #endif
 


### PR DESCRIPTION
This PR will enable the use of IPv6 addresses in all endpoints and the command line options. The support for IPv6 is enabled by default, but can be disabled during the project configuration with `--disable-ipv6` (just like the systemd support).

To be able to properly differentiate between IPv4 and IPv6 addresses, this PR will also add input validation for IP addresses. IPv6 addresses must always be enclosed in square brackets, like the usage in URLs. Otherwise the IP:Port notation can't be verified.
Because the config file does use two different keys for IP and port, the angled brackets are not needed technically. But using also them there makes the usage consistent throughout the application and will make the input validation and differentiation between IPv6 and IPv4 easier.

All unicast and multicast IPv6 IP addresses should be supported for sending and basically all addresses for receiving (eavesdropping mode). Link-local unicast and multicast worked just fine in a test between to devices.

This feature was also requested in #204.