### PR TITLE
log: use base_mode rather than system_status

### DIFF
--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -436,7 +436,7 @@ void LogEndpoint::_handle_auto_start_stop(uint32_t msg_id, uint8_t source_system
             && source_component_id == MAV_COMP_ID_AUTOPILOT1) {
 
             const mavlink_heartbeat_t *heartbeat = (mavlink_heartbeat_t *)payload;
-            const bool is_armed = heartbeat->system_status == MAV_STATE_ACTIVE;
+            const bool is_armed = heartbeat->base_mode & MAV_MODE_FLAG_SAFETY_ARMED;
 
             if (_file == -1 && is_armed) {
                 if (!start()) _mode = LogMode::disabled;


### PR DESCRIPTION
system_status is not a good field to get the "armed" state from: the
flight stack may change the system_status if for example a failsafe
condition is hit.  Derive the "armed" check from the base_mode field
that has a flag exactly with this meaning.

Thanks to Dan Moss for finding the issue.

Fix #226.